### PR TITLE
Match editorPane.background color with editor.background

### DIFF
--- a/themes/matchalk-color-theme.json
+++ b/themes/matchalk-color-theme.json
@@ -88,7 +88,7 @@
     "editorOverviewRuler.modifiedForeground": "#ba8eaf",
     "editorOverviewRuler.selectionHighlightForeground": "#d2b48c",
     "editorOverviewRuler.warningForeground": "#ba8eaf",
-    "editorPane.background": "#032139",
+    "editorPane.background": "#273136",
     "editorRuler.foreground": "#d2b48c",
     "editorSuggestWidget.background": "#323e45",
     "editorSuggestWidget.border": "#7eb08a80",


### PR DESCRIPTION
Currently, the editor pane's background is blue which contrasts with the greenish-gray editor background. This becomes evident when using the centered editor layout, as well as when viewing Jupyter Notebooks (see https://github.com/lucafalasco/matchalk/issues/3).

This commit makes the editor pane background color match that of the editor.

I understand if this contrast is desired and intentional. In lieu of this PR, if anyone wants to replicate this change in your own editor, you can [customize the theme](https://code.visualstudio.com/docs/editor/themes#_customize-a-color-theme) by adding the following snippet to your user settings.json:

```json
"workbench.colorCustomizations": {
    "[Matchalk]": {
        "editorPane.background": "#273136"
    }
}
```

## Preview

Here are before-and-after screenshots of the centered editor layout and Jupyter Notebook view:

### Before

<img width="1390" alt="Centered Editor Layout - Before" src="https://github.com/user-attachments/assets/29f370af-6318-44d1-989d-5c487e3b62a3" />

<img width="1065" alt="Jupyter Notebook - Before" src="https://github.com/user-attachments/assets/1c7fb538-af43-4a07-b639-9c5e0dde7c21" />

### After

<img width="1395" alt="Centered Editor Layout - After" src="https://github.com/user-attachments/assets/a5e85ef4-af46-4b92-9cd2-802a698c3eca" />
<img width="1063" alt="Jupyter Notebook - After" src="https://github.com/user-attachments/assets/6a536b5b-e37e-45ab-9cd5-d86f8487dde5" />

---

By the way, I love matchalk. Thank you for the beautiful theme. 🍃 